### PR TITLE
Resolve issue with invalid ProductAttributeValue class created by a factory

### DIFF
--- a/spec/Factory/ProductAttributeValueFactorySpec.php
+++ b/spec/Factory/ProductAttributeValueFactorySpec.php
@@ -13,10 +13,16 @@ namespace spec\BitBag\OpenMarketplace\Factory;
 
 use BitBag\OpenMarketplace\Factory\ProductAttributeValueFactoryInterface;
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Product\Model\ProductAttributeValue;
 use Sylius\Component\Product\Model\ProductAttributeValueInterface;
 
 final class ProductAttributeValueFactorySpec extends ObjectBehavior
 {
+    public function let(): void
+    {
+        $this->beConstructedWith(ProductAttributeValue::class);
+    }
+
     public function it_is_initializable(): void
     {
         $this->shouldHaveType(ProductAttributeValueFactoryInterface::class);

--- a/src/Factory/ProductAttributeValueFactory.php
+++ b/src/Factory/ProductAttributeValueFactory.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace BitBag\OpenMarketplace\Factory;
 
-use Sylius\Component\Product\Model\ProductAttributeValue;
 use Sylius\Component\Product\Model\ProductAttributeValueInterface;
 
 final class ProductAttributeValueFactory implements ProductAttributeValueFactoryInterface

--- a/src/Factory/ProductAttributeValueFactory.php
+++ b/src/Factory/ProductAttributeValueFactory.php
@@ -16,8 +16,15 @@ use Sylius\Component\Product\Model\ProductAttributeValueInterface;
 
 final class ProductAttributeValueFactory implements ProductAttributeValueFactoryInterface
 {
+    private string $classFQN;
+
+    public function __construct(string $classFQN)
+    {
+        $this->classFQN = $classFQN;
+    }
+
     public function create(): ProductAttributeValueInterface
     {
-        return new ProductAttributeValue();
+        return new $this->classFQN();
     }
 }

--- a/src/Resources/config/services/factory.xml
+++ b/src/Resources/config/services/factory.xml
@@ -120,7 +120,7 @@
 
         <service class="BitBag\OpenMarketplace\Factory\ProductAttributeValueFactory"
                  id="open_marketplace.factory.product_attribute_value">
-
+            <argument type="string">%sylius.model.product_attribute_value.class%</argument>
         </service>
 
         <service class="BitBag\OpenMarketplace\Factory\VendorShippingMethodFactory"


### PR DESCRIPTION
The issue could be found during fixtures loading when extended ProductAttributeValue class