### PR TITLE
[MUL-269] Display main image twice fix

### DIFF
--- a/templates/bundles/SyliusShopBundle/Product/Show/_images.html.twig
+++ b/templates/bundles/SyliusShopBundle/Product/Show/_images.html.twig
@@ -1,0 +1,42 @@
+{% set mainPhoto = null %}
+
+{% if product.imagesByType('main') is not empty %}
+    {% set mainPhoto = product.imagesByType('main').first %}
+{% elseif product.images.first %}
+    {% set mainPhoto = product.images.first %}
+{% endif %}
+
+{% if mainPhoto is not null %}
+    {% set source_path = mainPhoto.path %}
+    {% set original_path = source_path|imagine_filter('sylius_shop_product_original') %}
+    {% set path = source_path|imagine_filter(filter|default('sylius_shop_product_large_thumbnail')) %}
+{% else %}
+    {% set original_path = asset('assets/shop/img/400x300.png') %}
+    {% set path = original_path %}
+{% endif %}
+
+<div data-product-image="{{ path }}" data-product-link="{{ original_path }}"></div>
+<a href="{{ original_path }}" class="ui fluid image" data-lightbox="sylius-product-image">
+    <img src="{{ path }}" id="main-image" alt="{{ product.name }}" {{ sylius_test_html_attribute('main-image') }} />
+</a>
+{% if product.images|length > 1 %}
+    <div class="ui divider"></div>
+
+    {{ sylius_template_event('sylius.shop.product.show.before_thumbnails', {'product': product}) }}
+
+    <div class="ui small images">
+        {% for image in product.images if mainPhoto != image %}
+            {% set path = image.path is not null
+                ? image.path|imagine_filter('sylius_shop_product_small_thumbnail')
+                : asset('assets/shop/img/200x200.png') %}
+            <div class="ui image">
+                {% if product.isConfigurable() and product.enabledVariants|length > 0 %}
+                    {% include '@SyliusShop/Product/Show/_imageVariants.html.twig' %}
+                {% endif %}
+                <a href="{{ image.path|imagine_filter('sylius_shop_product_original') }}" data-lightbox="sylius-product-image">
+                    <img src="{{ path }}" data-large-thumbnail="{{ image.path|imagine_filter('sylius_shop_product_large_thumbnail') }}" alt="{{ product.name }}" />
+                </a>
+            </div>
+        {% endfor %}
+    </div>
+{% endif %}


### PR DESCRIPTION
By default sylius displays main photo twice, this PR assures that mainPhoto extracted at the beginning doesn't appear in subphotos underneath.

Build failed due to removal of EntityManager::merge() method.
Will be fixed in the future. 